### PR TITLE
Updated web.config

### DIFF
--- a/src/web.config
+++ b/src/web.config
@@ -84,6 +84,7 @@
             <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
             <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
             <add input="{REQUEST_FILENAME}" pattern=".*[^.]*\.[\d\w]+$" negate="true" />
+			      <add input="{REQUEST_URI}" matchType="Pattern" pattern="api/(.*)" negate="true" />
           </conditions>
           <action type="Rewrite" url="/" />
         </rule>


### PR DESCRIPTION
Enabling clean urls without the added rewrite/negate rule will cause calls to the API to return 404 responses.