### PR TITLE
Lookup project name validation per organization

### DIFF
--- a/src/app/project/add.tpl.html
+++ b/src/app/project/add.tpl.html
@@ -39,6 +39,7 @@
                        ng-model="vm.project_name"
                        ng-model-options="{ debounce: 500 }"
                        project-name-available-validator
+                       organization-id="vm.currentOrganization.id"
                        ng-required="true"
                        autofocus />
 

--- a/src/components/project/project-service.js
+++ b/src/components/project/project-service.js
@@ -60,8 +60,8 @@
         return _cachedRestangular.one('users', userId).one('projects', id).one('notifications').get();
       }
 
-      function isNameAvailable(name) {
-        return Restangular.one('projects', 'check-name').get({ name: encodeURIComponent(name) });
+      function isNameAvailable(organizationId, name) {
+        return Restangular.one('organizations', organizationId).one('projects', 'check-name').get({ name: encodeURIComponent(name) });
       }
 
       function promoteTab(id, name) {

--- a/src/components/validators/project-name-available-validator.js
+++ b/src/components/validators/project-name-available-validator.js
@@ -6,6 +6,9 @@
       return {
         restrict: 'A',
         require: 'ngModel',
+        scope: {
+          organizationId: "="
+        },
         link: function(scope, element, attrs, ngModel) {
           ngModel.$asyncValidators.unique = function(name) {
             var deferred = $q.defer();
@@ -15,7 +18,7 @@
                 deferred.resolve(true);
               }, 0);
             } else {
-              projectService.isNameAvailable(name).then(function(response) {
+              projectService.isNameAvailable(scope.organizationId, name).then(function(response) {
                 if (response.status === 201) {
                   deferred.reject('');
                 } else {
@@ -28,6 +31,10 @@
 
             return deferred.promise;
           };
+
+          scope.$watch("organizationId", function() {
+            ngModel.$validate();
+          });
         }
       };
     });

--- a/src/components/validators/project-name-available-validator.js
+++ b/src/components/validators/project-name-available-validator.js
@@ -17,6 +17,8 @@
               $timeout(function() {
                 deferred.resolve(true);
               }, 0);
+            } else if (scope.organizationId == "__newOrganization") {
+              deferred.resolve(true);
             } else {
               projectService.isNameAvailable(scope.organizationId, name).then(function(response) {
                 if (response.status === 201) {

--- a/src/components/validators/project-name-available-validator.js
+++ b/src/components/validators/project-name-available-validator.js
@@ -17,7 +17,7 @@
               $timeout(function() {
                 deferred.resolve(true);
               }, 0);
-            } else if (scope.organizationId == "__newOrganization") {
+            } else if (scope.organizationId === "__newOrganization") {
               deferred.resolve(true);
             } else {
               projectService.isNameAvailable(scope.organizationId, name).then(function(response) {


### PR DESCRIPTION
Uniqueness has previously been filtering for a project name in any organizations, not only the current selected organization - preventing project name to be reused towards different organizations.

The backend supports this, as well as the API have allowed doing proper lookup through a previous implementation (https://github.com/exceptionless/Exceptionless/pull/155).

This change will take advantage of the API change, fixing the validation issue.

This should also solve #38.