### PR TITLE
Support multiline strings in Extended Data

### DIFF
--- a/src/components/object-dump/handlebars-service.js
+++ b/src/components/object-dump/handlebars-service.js
@@ -6,7 +6,7 @@
   angular.module('exceptionless.object-dump')
     .factory('handlebarsService', function () {
       var _defaultsRegistered = false;
-      var _templates = { __default: '{{> valueDump}}' };
+      var _templates = { __default: '{{> valueDump}}', pre: '{{#ifHasData this}}<pre>{{> valueDump}}</pre>{{/ifHasData}}' };
       var _compiledTemplates = {};
 
       function getTemplate(templateKey) {

--- a/src/components/object-dump/object-dump-directive.js
+++ b/src/components/object-dump/object-dump-directive.js
@@ -17,8 +17,8 @@
           }
 
           try {
-            var content = scope.content,
-                template = handlebarsService.getTemplate(scope.templateKey);
+            var content = scope.content;
+            var template = handlebarsService.getTemplate(scope.templateKey);
 
             if (typeof content === 'string' || content instanceof String) {
               try {

--- a/src/components/object-dump/object-dump-directive.js
+++ b/src/components/object-dump/object-dump-directive.js
@@ -17,12 +17,17 @@
           }
 
           try {
-            var content = scope.content;
+            var content = scope.content,
+                template = handlebarsService.getTemplate(scope.templateKey);
+
             if (typeof content === 'string' || content instanceof String) {
-              content = JSON.parse(scope.content);
+              try {
+                content = JSON.parse(scope.content);
+              } catch (ex) {
+                template = handlebarsService.getTemplate('pre');
+              }
             }
 
-            var template = handlebarsService.getTemplate(scope.templateKey);
             element.html(template(content));
           } catch (ex) {
             element.text(scope.content);


### PR DESCRIPTION
This will allow display of multiline strings as mentioned in #116, by wrapping content (non-JSON) into a `<pre>`-tag.
<img width="643" alt="Example with multiline content" src="https://cloud.githubusercontent.com/assets/317552/22618810/994b03fe-eae6-11e6-8116-287257002299.png">

Support (`.text`) kept for now, to fallback in any rare case.