### PR TITLE
tags now wrap to new line

### DIFF
--- a/src/less/labels.less
+++ b/src/less/labels.less
@@ -4,6 +4,6 @@
 
 .label {
   display: inline-block;
-  padding: .3em .6em .4em;
+  padding: .4em .6em .4em;
   margin-bottom: 3px;
 }

--- a/src/less/labels.less
+++ b/src/less/labels.less
@@ -1,3 +1,9 @@
 .panel-heading .label {
   display:inline-block;
 }
+
+.label {
+  display: inline-block;
+  padding: .3em .6em .4em;
+  margin-bottom: 3px;
+}


### PR DESCRIPTION
When you have too many tags they overflow to the right off the edge of the screen, now they wrap to the next line.

Closes #96