### PR TITLE
Remove the 'tags' field in stack view to avoid performance issue.

### DIFF
--- a/src/app/stack/stack.tpl.html
+++ b/src/app/stack/stack.tpl.html
@@ -135,6 +135,10 @@
               <th>Description</th>
               <td><span truncate lines="2">{{vm.stack.description}}</span></td>
             </tr>
+            <tr ng-if="vm.stack.tags.length > 0">
+              <th>Tags</th>
+              <td><span class="label label-info" ng-repeat="tag in vm.stack.tags.slice(0,25) track by tag">{{::tag}}</span></td>
+            </tr>
             <tr ng-if="vm.stack.references.length > 0">
               <th>{{(vm.stack.references.length > 1) ? 'Reference Links' : 'Reference Link'}}</th>
               <td>

--- a/src/app/stack/stack.tpl.html
+++ b/src/app/stack/stack.tpl.html
@@ -135,10 +135,6 @@
               <th>Description</th>
               <td><span truncate lines="2">{{vm.stack.description}}</span></td>
             </tr>
-            <tr ng-if="vm.stack.tags.length > 0">
-              <th>Tags</th>
-              <td><span class="label label-info" ng-repeat="tag in vm.stack.tags track by tag">{{tag}}</span></td>
-            </tr>
             <tr ng-if="vm.stack.references.length > 0">
               <th>{{(vm.stack.references.length > 1) ? 'Reference Links' : 'Reference Link'}}</th>
               <td>


### PR DESCRIPTION
In our in-house deployment, there are more than million events in every stack, usually there are more than billion events. The tags field will aggregate all the tags in all the stack events, then there will be more than thousand tags in the stack view. Every time we enter this view, the browser will be blocked due to rendering so many useless tags.
At the same time, I think this field should be removed in the server-side too, to avoid performance waste.