### PR TITLE
Fix bug: The projects cannot be retrieved when there are more than 100 projects in account.

### DIFF
--- a/src/components/project/project-service.js
+++ b/src/components/project/project-service.js
@@ -38,10 +38,10 @@
 
       function getAll(options, useCache) {
         if (useCache === undefined || useCache) {
-          return _cachedRestangular.all('projects').getList(angular.extend({}, { limit: 100 }, options));
+          return _cachedRestangular.all('projects').getList(angular.extend({}, { limit: 1000 }, options));
         }
 
-        return Restangular.all('projects').getList(angular.extend({}, { limit: 100 }, options));
+        return Restangular.all('projects').getList(angular.extend({}, { limit: 1000 }, options));
       }
 
       function getById(id, useCache) {


### PR DESCRIPTION
There are more than 100 organizations in my account, and there are no more than three projects for each organization. So totally there are more than 200 projects. But some of organizations were displayed without any project in the filter drop down.
![qq 20170908164438](https://user-images.githubusercontent.com/2819989/30203761-bf9fd7cc-94b5-11e7-8893-02f884ccd169.png)

and tell me to add new project for these organizations.
![qq 20170908164920](https://user-images.githubusercontent.com/2819989/30203762-bff58848-94b5-11e7-9602-09a9a98a28cf.png)

Actually we have created projects for these organizations
![qq 20170908165213](https://user-images.githubusercontent.com/2819989/30203847-1716e0b8-94b6-11e7-83b3-9d5ad9899333.png)

So loose the limit to 1000 to retrieve all the projects in the project service, it can fix this problem.