### PR TITLE
Redirect to desired url after login

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -308,13 +308,13 @@
       }
     };
 
-    $rootScope.$on('$stateChangeStart', function (event, toState) {
+    $rootScope.$on('$stateChangeStart', function (event, toState, toParams) {
       if (!toState || !toState.data || !toState.data.requireAuthentication)
         return;
 
       if (!authService.isAuthenticated()) {
         event.preventDefault();
-        stateService.save(['auth.']);
+        stateService.saveRequested(['auth.'], toState.name, toParams);
         $state.transitionTo('auth.login');
       }
 

--- a/src/components/state/state-service.js
+++ b/src/components/state/state-service.js
@@ -35,9 +35,25 @@
       _store.put('params', $state.params);
     }
 
+    function saveRequested(exclusions, requestedStateName, requestedStateParams) {
+      save(exclusions);
+
+      if (!requestedStateName) {
+        return;
+      }
+
+      if (_store.get('name', false)) {
+        return;
+      }
+
+      _store.put('name', requestedStateName);
+      _store.put('params', requestedStateParams);
+    }
+
     var service = {
       clear: clear,
       restore: restore,
+      saveRequested: saveRequested,
       save: save
     };
 


### PR DESCRIPTION
If you are prompted to login when someone share an Exceptionless link, after login you will be redirected to the dashboard instead of original link.
I’ve changed this behaviour in this pull request, so you will get desired url after login.
